### PR TITLE
[fix-width] Fix width

### DIFF
--- a/style.css
+++ b/style.css
@@ -126,7 +126,7 @@ span {
 
 @media only screen and (min-width: 1000px) {
     .wrapper {
-        width: max-content;
+        width: 100%;
         margin: auto;
     }
 


### PR DESCRIPTION
Width 100% means the container will take the width of the parent. So if we make the parent container width: 100%, then the children will be 100%

### Before
![Screen Shot 2022-08-19 at 10 09 42 AM](https://user-images.githubusercontent.com/51972068/185671596-d2d65225-fa6c-4cfb-9aee-baa7fc09889a.png)


### After
![Screen Shot 2022-08-19 at 10 09 15 AM](https://user-images.githubusercontent.com/51972068/185671521-2339e8f9-6a35-499b-acc0-ba674feefe7d.png)
